### PR TITLE
This PR fixes issue with JSON decoder crashing on some properties & links

### DIFF
--- a/Forensicsim_Parser.py
+++ b/Forensicsim_Parser.py
@@ -303,7 +303,7 @@ class ForensicIMIngestModule(DataSourceIngestModule):
                 BlackboardAttribute(self.att_reaction_timestamp, ForensicIMIngestModuleFactory.moduleName,
                                     timestamp))
             self.index_artifact(art)
-        except TskCoreException as ex:
+        except (Exception, TskCoreException) as ex:
             # Severe error trying to add to case database.. case is not complete.
             # These exceptions are thrown by the CommunicationArtifactsHelper.
             self._logger.log(Level.SEVERE,
@@ -328,7 +328,7 @@ class ForensicIMIngestModule(DataSourceIngestModule):
                     BlackboardAttribute(BlackboardAttribute.ATTRIBUTE_TYPE.TSK_ID, ARTIFACT_PREFIX, contact['mri']))
                 helper.addContact(contact_name, contact_phone_number, contact_home_phone_number,
                                   contact_mobile_phone_number, contact_email, additional_attributes)
-        except TskCoreException as e:
+        except (TskCoreException, Exception) as e:
             self._logger.log(Level.SEVERE,
                              "Error adding Microsoft Teams contact artifacts to the case database.", e)
         except BlackboardException as e:
@@ -347,7 +347,7 @@ class ForensicIMIngestModule(DataSourceIngestModule):
                 end_date = self.date_to_long(call['properties']['call-log']['endTime'])
 
                 helper.addCalllog(call_direction, from_address, to_address, start_date, end_date, CallMediaType.UNKNOWN)
-        except TskCoreException as ex:
+        except (Exception, TskCoreException) as ex:
             # These exceptions are thrown by the CommunicationArtifactsHelper.
             self._logger.log(Level.SEVERE,
                              "Failed to add call log artifacts to the case database.", ex)
@@ -423,7 +423,7 @@ class ForensicIMIngestModule(DataSourceIngestModule):
 
 
 
-        except TskCoreException as ex:
+        except (Exception, TskCoreException) as ex:
             # Severe error trying to add to case database.. case is not complete.
             # These exceptions are thrown by the CommunicationArtifactsHelper.
             self._logger.log(Level.SEVERE,
@@ -463,7 +463,7 @@ class ForensicIMIngestModule(DataSourceIngestModule):
                                         calendar_entry_organizer))
                 self.index_artifact(art)
 
-        except TskCoreException as ex:
+        except (Exception, TskCoreException) as ex:
             # Severe error trying to add to case database.. case is not complete.
             # These exceptions are thrown by the CommunicationArtifactsHelper.
             self._logger.log(Level.SEVERE,

--- a/main.spec
+++ b/main.spec
@@ -5,7 +5,7 @@ block_cipher = None
 
 a = Analysis(['utils\\main.py'],
              binaries=[],
-             datas=[('C:/Python39/Lib/site-packages/pyfiglet', 'pyfiglet')],
+             datas=[('C:/Python310/Lib/site-packages/pyfiglet', 'pyfiglet')],
              hiddenimports=[],
              hookspath=[],
              runtime_hooks=[],

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pyfiglet~=0.8.post1
 colorama~=0.4.4
 beautifulsoup4~=4.9.3
 click~=8.0.1
+wxPython

--- a/utils/main.py
+++ b/utils/main.py
@@ -199,7 +199,6 @@ def parse_reply_chain(reply_chains):
                     except UnicodeDecodeError or KeyError  or NameError as e:
                         print("Could not decode the following item in the reply chain (output is not deduplicated).")
                         print("\t ", value)
-                        raise e
 
     # Deduplicate based on cachedDeduplicationKey, as messages appear often multiple times within
     cleaned = deduplicate(cleaned, 'cachedDeduplicationKey')

--- a/utils/main.py
+++ b/utils/main.py
@@ -94,7 +94,8 @@ def decode_and_loads(properties):
     if (type(properties) is bytes):
         soup = BeautifulSoup(properties, features="html.parser")
         properties = properties.decode(soup.original_encoding)
-    return json.loads(properties)
+
+    return json.loads(properties, strict=False)
 
 def parse_contacts(contacts):
     cleaned = []
@@ -194,9 +195,11 @@ def parse_reply_chain(reply_chains):
                         # Other types include ThreadActivity/TopicUpdate and ThreadActivity/AddMember
                         # -> ThreadActivity/TopicUpdate occurs for meeting updates
                         # -> ThreadActivity/AddMember occurs when someone gets added to a chat
+
                     except UnicodeDecodeError or KeyError  or NameError as e:
                         print("Could not decode the following item in the reply chain (output is not deduplicated).")
                         print("\t ", value)
+                        raise e
 
     # Deduplicate based on cachedDeduplicationKey, as messages appear often multiple times within
     cleaned = deduplicate(cleaned, 'cachedDeduplicationKey')

--- a/utils/shared.py
+++ b/utils/shared.py
@@ -179,7 +179,7 @@ def parse_localstorage(filepath):
     extracted_values = []
     for record in local_store.iter_all_records():
         try:
-            extracted_values.append(json.loads(record.value))
+            extracted_values.append(json.loads(record.value, strict=False))
         except json.decoder.JSONDecodeError:
             continue
     return extracted_values


### PR DESCRIPTION
Hi Alex!

Thanks for the terrific tool! I've fixed a bug that you left in reply chain decoding.
Some Teams properties.links JSONs are not strictly following JSON structure, causing json.loads to throw exception.

This is the faulty code snippet in `main.py`:

```
def decode_and_loads(properties):
    if (type(properties) is bytes):
        soup = BeautifulSoup(properties, features="html.parser")
        properties = properties.decode(soup.original_encoding)

    return json.loads(properties)
```

Example exception that was being thrown was related to unexpected characters in JSON streams.

```
Could not decode the following item in the reply chain (output is not deduplicated).
```

All it takes to mitigate the issue is to utilize `strict=False` parameter of PyJson.

Kind regards,
Mariusz.