### PR TITLE
Another fix for big teams users

### DIFF
--- a/src/forensicsim/backend.py
+++ b/src/forensicsim/backend.py
@@ -53,6 +53,14 @@ Additionally, it has a flag to filter for datastores, which are interesting for 
 """
 
 
+def decode_truncated_int(data: bytes) -> int:
+    if len(data) == 0:
+        raise ValueError("No data to decode")
+    result = 0
+    for i, b in enumerate(data):
+        result |= (b << (i * 8))
+    return result
+
 class FastIndexedDB:
     def __init__(self, leveldb_dir: os.PathLike):
         self._db = ccl_leveldb.RawLevelDb(leveldb_dir)
@@ -122,7 +130,7 @@ class FastIndexedDB:
                         (
                             objstore_id,
                             varint_raw,
-                        ) = ccl_chromium_indexeddb.custom_le_varint_from_bytes(
+                        ) = decode_truncated_int(
                             record.key[len(prefix_objectstore) :]
                         )
                     except TypeError:
@@ -192,7 +200,7 @@ class FastIndexedDB:
                             (
                                 _value_version,
                                 varint_raw,
-                            ) = ccl_chromium_indexeddb.custom_le_varint_from_bytes(
+                            ) = decode_truncated_int(
                                 record.value
                             )
                             val_idx = len(varint_raw)
@@ -205,7 +213,7 @@ class FastIndexedDB:
                             (
                                 _,
                                 varint_raw,
-                            ) = ccl_chromium_indexeddb.custom_le_varint_from_bytes(
+                            ) = decode_truncated_int(
                                 record.value[val_idx:]
                             )
 


### PR DESCRIPTION
Another fix 
the creator of ccl_chrome_indexeddb
seemed to had fixe some database-id issues 

"""""""""""""""""""
Fixed how database id/maximum object store id was being read.
Assumption had been made that it was a varint as the value was a single byte for < 128 but this is not the case, it is a truncated 64-bit integer, encoded using only the bytes that are needed for.
Previous versions would work properly for IDB with fewer than 127 databases and databases with fewer than 127 object stores, but will have either crashed or missed databases/object stores when those conditions were not satisfied (depending on the value being read: 128 - 255 would have crashed, which likely accounts for the vast majority).

An additional test data generator html page has been included to test these case.
"""""""""""""""