### PR TITLE
Fixed bug with missing guid and missing blob files

### DIFF
--- a/src/forensicsim/backend.py
+++ b/src/forensicsim/backend.py
@@ -62,7 +62,7 @@ def parse_db(
             if obj_store_name in TEAMS_DB_OBJECT_STORES or filter_db_results is False:
                 obj_store = db[obj_store_name]
                 records_per_object_store = 0
-                for record in obj_store.iterate_records():
+                for record in obj_store.iterate_records(errors_to_stdout=True):
                     # skip empty records
                     if not hasattr(record, "value") or record.value is None:
                         continue
@@ -112,7 +112,7 @@ def parse_sessionstorage(filepath: Path) -> list[dict[str, Any]]:
                 entry = {
                     "key": host,
                     "value": session_store_value.value,
-                    "guid": session_store_value.guid,
+                    "guid": session_store_value.guid if hasattr(session_store_value, "guid") else "",
                     "leveldb_sequence_number": session_store_value.leveldb_sequence_number,
                 }
                 extracted_values.append(entry)


### PR DESCRIPTION
Line 65: If `errors_to_stdout=True` is not set for `obj_store.iterate_records`, a missing blob file triggers a `FileNotFoundError` in `ccl_chromium_indexeddb.py` line 571 respectively 668.

Line 115: In my test cases, some `session_store_value`s had no attribute `guid`, triggering a `AttributeError`. Therefore, I added a default value