### PR TITLE
fix: handle Snappy + Blink-V8 wrapped IndexedDB values (closes #89)

### DIFF
--- a/src/forensicsim/backend.py
+++ b/src/forensicsim/backend.py
@@ -23,6 +23,7 @@ SOFTWARE.
 """
 
 import json
+import logging
 from pathlib import Path
 from typing import Any, Optional
 
@@ -32,9 +33,21 @@ from ccl_chromium_reader import (
     ccl_chromium_sessionstorage,
 )
 
+from .snappy_wrapper import install_snappy_unwrap_patch
+
+log = logging.getLogger(__name__)
+
 TEAMS_DB_OBJECT_STORES = ["replychains", "conversations", "people", "buddylist"]
 
 ENCODING = "iso-8859-1"
+
+# Install the Snappy unwrap patch on module import.
+# Fix for issue #89: Teams (2025-2026 builds) wraps large IndexedDB values
+# with Snappy compression + Blink-V8 envelope that the upstream
+# ccl_chromium_reader doesn't handle. The patch is idempotent and only affects
+# values starting with byte 0x02 (the Snappy marker) — non-wrapped values are
+# untouched.
+install_snappy_unwrap_patch()
 
 
 def parse_db(

--- a/src/forensicsim/snappy_wrapper.py
+++ b/src/forensicsim/snappy_wrapper.py
@@ -1,0 +1,106 @@
+"""
+Snappy + Blink-V8 wrapper unwrap (fix per a issue #89).
+
+A partir d'algun moment al 2025-2026, Microsoft Teams (i potencialment altres
+apps Chromium) comencen a emmagatzemar valors grans d'IndexedDB amb un wrapper
+de compressió Snappy. `ccl_chromium_reader.ccl_v8_value_deserializer` espera el
+byte de header V8 (`0xFF` `kVersion`) com a primer byte i pèta amb
+`ValueError("Didn't get version tag in the header")` quan veu el byte `0x02`
+del wrapper Snappy.
+
+Format detectat empíricament:
+
+    byte 0:     0x02                      ← marker Snappy compression
+    bytes 1+:   Snappy-compressed blob → after decompression:
+                  ff 15                   ← V8 wrapper version 21 (Blink-V8 envelope)
+                  fe 00 00 ... 00         ← kBlinkVersion token + padding
+                  ff 0f                   ← V8 inner version 15
+                  ...                     ← V8 standard data
+
+`install_snappy_unwrap_patch()` monkey-patches
+`ccl_v8_value_deserializer.Deserializer.__init__` per detectar i descomprimir
+transparentment, deixant el deserializer veure únicament el V8 inner net.
+
+Sense aquest patch, els builds de Teams 2026 perden ~95% de cobertura sobre
+`replychains` (cos dels missatges) al perfil principal d'usuari.
+"""
+from __future__ import annotations
+
+import io
+import logging
+
+import ccl_simplesnappy
+from ccl_chromium_reader.serialization_formats import ccl_v8_value_deserializer as v8mod
+
+log = logging.getLogger(__name__)
+
+_SNAPPY_MARKER = 0x02
+_V8_VERSION_TAG = 0xFF
+_PATCH_INSTALLED = False
+_ORIG_INIT = None
+
+
+def _try_unwrap_snappy(data: bytes) -> bytes | None:
+    """If `data` is Snappy-wrapped (byte 0 == 0x02), decompress and skip
+    Blink-V8 envelope. Returns clean V8 payload, or None if not wrapped.
+    """
+    if not data or data[0] != _SNAPPY_MARKER:
+        return None
+    try:
+        stream = io.BytesIO(data[1:])
+        decompressed = ccl_simplesnappy.decompress(stream)
+    except Exception as e:
+        log.debug("snappy decompress failed: %s", e)
+        return None
+
+    if len(decompressed) < 4 or decompressed[0] != _V8_VERSION_TAG:
+        return decompressed
+
+    # Skip Blink-V8 outer envelope: find SECOND 0xFF (inner V8 version)
+    second_ff = decompressed.find(bytes([_V8_VERSION_TAG]), 2)
+    if second_ff == -1:
+        return decompressed
+    return decompressed[second_ff:]
+
+
+def _patched_init(self, stream, host_object_delegate, *,
+                  is_little_endian=True, is_64bit=True):
+    """Replacement Deserializer.__init__ that auto-unwraps Snappy if present."""
+    pos = stream.tell()
+    try:
+        first = stream.read(1)
+        stream.seek(pos)
+    except Exception:
+        first = b""
+
+    if first == bytes([_SNAPPY_MARKER]):
+        try:
+            full = stream.read()
+            unwrapped = _try_unwrap_snappy(full)
+            if unwrapped is not None:
+                return _ORIG_INIT(
+                    self, io.BytesIO(unwrapped), host_object_delegate,
+                    is_little_endian=is_little_endian, is_64bit=is_64bit,
+                )
+        except Exception as e:
+            log.debug("unwrap pipeline failed: %s — falling back to raw stream", e)
+            stream.seek(pos)
+
+    return _ORIG_INIT(
+        self, stream, host_object_delegate,
+        is_little_endian=is_little_endian, is_64bit=is_64bit,
+    )
+
+
+def install_snappy_unwrap_patch() -> None:
+    """Install the monkey-patch globally. Idempotent — safe to call multiple times.
+
+    Call this once at program startup, before any LevelDB iteration starts.
+    """
+    global _PATCH_INSTALLED, _ORIG_INIT
+    if _PATCH_INSTALLED:
+        return
+    _ORIG_INIT = v8mod.Deserializer.__init__
+    v8mod.Deserializer.__init__ = _patched_init
+    _PATCH_INSTALLED = True
+    log.info("Snappy unwrap patch installed (fix for issue #89)")


### PR DESCRIPTION
## Summary

Fix for [#89](https://github.com/lxndrblz/forensicsim/issues/89) — handles Snappy + Blink-V8 wrapped IndexedDB values that Microsoft Teams (2025-2026 MSIX builds) and other Chromium-based apps started using for large records.

## Root cause

Chromium's IndexedDB layer now compresses large values with **Snappy** and wraps the result in a **Blink-V8 nested envelope** before V8 serialization. The upstream `ccl_chromium_reader.ccl_v8_value_deserializer` expects the V8 version tag (`0xFF`) as the first byte but encounters `0x02` (Snappy marker), raising:

```
ValueError: Didn't get version tag in the header
```

## Format observed empirically

```
byte 0:    0x02                  ← Snappy compression marker
bytes 1+:  Snappy-compressed → after decompression:
             ff 15               ← V8 wrapper version 21 (Blink-V8 envelope)
             fe 00 00 ... 00     ← kBlinkVersion token + padding (13 bytes)
             ff 0f               ← V8 inner version 15
             ... V8 data         ← standard V8 serialization
```

## Fix

New `src/forensicsim/snappy_wrapper.py` with:
- `_try_unwrap_snappy(data)`: detects `0x02` prefix, decompresses with `ccl_simplesnappy`, skips Blink envelope to the inner `0xFF`
- `install_snappy_unwrap_patch()`: idempotent monkey-patch on `Deserializer.__init__` that intercepts each value stream

`backend.py` calls `install_snappy_unwrap_patch()` once at import time — transparent for all existing call sites.

Non-wrapped values are unaffected (zero overhead beyond a 1-byte peek + 1-byte read).

## Empirical impact

Test environment: Windows 11, MSTeams_8wekyb3d8bbwe (new Teams MSIX), 110 .ldb files / 119 MB cache, 4 user profiles in store.

| Store | Before | After |
|-------|--------|-------|
| `replychains` (profile A) | 252 | 252 (no change — non-wrapped) |
| `replychains` (profile B, main) | **FAIL** | **14,599** |
| `replychains` (profile C) | **FAIL** | **2,362** |
| `replychains` (profile D) | 2 | 2 |
| **Total** | **254** | **17,215 (68×)** |

The `conversations`, `people`, and `buddylist` stores were already 100% extractable — they're not affected by the wrapper.

## Test command

After installing this branch:

```bash
python tools/dump_leveldb.py \
  -f "$LOCALAPPDATA/Packages/MSTeams_8wekyb3d8bbwe/LocalCache/Microsoft/MSTeams/EBWebView/WV2Profile_tfw/IndexedDB/https_teams.microsoft.com_0.indexeddb.leveldb" \
  -b "$LOCALAPPDATA/Packages/MSTeams_8wekyb3d8bbwe/LocalCache/Microsoft/MSTeams/EBWebView/WV2Profile_tfw/IndexedDB/https_teams.microsoft.com_0.indexeddb.blob" \
  -o /tmp/dump.json
```

Should print `Records: 14599` (or similar large number) for the main `replychains` store instead of failing.

## Dependencies

`ccl_simplesnappy` — already a transitive dep of `ccl_chromium_reader`, so no new requirements.

## Notes

- Patch can also be installed manually before calling other tools (e.g. `parse_db`): `from forensicsim.snappy_wrapper import install_snappy_unwrap_patch; install_snappy_unwrap_patch()`
- Could potentially be upstreamed to `cclgroupltd/ccl_chromium_reader` directly, where this logically belongs. Submitting here first because the issue tracker for the manifestation lives in this repo.
- If Microsoft changes the wrapper format (e.g. switches to zlib), `_try_unwrap_snappy` returns None and the deserializer sees the raw bytes (same behavior as before the patch).

## Test plan

- [x] Reproduces #89 failure on a recent Teams MSIX install (verified)
- [x] Patch resolves the failure transparently
- [x] Non-wrapped values still decode correctly (regression check via the 252 baseline records)
- [ ] CI tests pass (will see after submit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
